### PR TITLE
Issue #6: Upgrade dependencies

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,11 +8,11 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8 ]
+        java-version: [ 17 ]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: adopt
         java-version: ${{ matrix.java-version }}

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -12,11 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8 ]
+        java-version: [ 17 ]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: adopt
         java-version: ${{ matrix.java-version }}
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up settings.xml for GitHub Packages
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 8
+          java-version: 17
 
       - name: Publish SNAPSHOT version to GitHub Packages (we can skip tests, since we only deploy, if the build workflow succeeded)
         run: mvn -B --no-transfer-progress deploy -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.averbis.textanalysis</groupId>
@@ -36,11 +38,17 @@
 	</scm>
 
 	<properties>
-		<java-version>17</java-version>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.release>17</maven.compiler.release>
+		<maven.compiler.proc>none</maven.compiler.proc>
+		<execution.environment>JavaSE-17</execution.environment>
+
+		<bnd-version>7.1.0</bnd-version>
 		<maven-version>3.8.1</maven-version>
-		<uima-version>3.6.0-SNAPSHOT</uima-version>
-		<bnd-version>7.0.0</bnd-version>
-		<saxon-version>8.7</saxon-version>
+		<uima-version>3.6.0</uima-version>
+		<saxon.version>8.7</saxon.version>
+
 		<typesystem-stylesheet-location>${basedir}/../doc/typesystem.xslt</typesystem-stylesheet-location>
 		
 		<osgi-export-package>!*</osgi-export-package>
@@ -79,7 +87,7 @@
 									<version>${maven-version}</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
-									<version>${java-version}</version>
+									<version>${maven.compiler.release}</version>
 								</requireJavaVersion>
 							</rules>
 						</configuration>
@@ -96,7 +104,6 @@
 					<release>${java-version}</release>
 				</configuration>
 			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -170,6 +177,18 @@
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>3.2.7</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.4.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.13.0</version>
 				</plugin>
@@ -177,7 +196,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.10.0</version>
+					<version>3.11.1</version>
 				</plugin>
 
 				<plugin>
@@ -203,56 +222,17 @@
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>3.7.1</version>
 				</plugin>
-
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-clean-plugin</artifactId>
-					<version>3.4.0</version>
-				</plugin>
-
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-gpg-plugin</artifactId>
-					<version>3.2.6</version>
-				</plugin>
 				
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.5.0</version>
+					<version>3.5.2</version>
 				</plugin>
 
-				<plugin>
-					<groupId>org.apache.felix</groupId>
-					<artifactId>maven-bundle-plugin</artifactId>
-					<version>5.1.9</version>
-				</plugin>
-
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
-					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>
 					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.codehaus.mojo</groupId>
-										<artifactId>xml-maven-plugin</artifactId>
-										<versionRange>[1.0,)</versionRange>
-										<goals>
-											<goal>transform</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -405,8 +385,10 @@
 									<stylesheet>${typesystem-stylesheet-location}</stylesheet>
 									<outputDir>${project.build.directory}/generated-sources/doc</outputDir>
 									<fileMappers>
-										<fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper" />
-										<fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+										<fileMapper
+											implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper" />
+										<fileMapper
+											implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
 											<targetExtension>.adoc</targetExtension>
 										</fileMapper>
 									</fileMappers>
@@ -425,7 +407,7 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-resources-plugin</artifactId>
 						<executions>
-						<!-- Copies the xml docs to doc/sources -->
+							<!-- Copies the xml docs to doc/sources -->
 							<execution>
 								<id>copy-docs</id>
 								<phase>prepare-package</phase>
@@ -502,6 +484,46 @@
 						</executions>
 					</plugin>
 				</plugins>
+			</build>
+		</profile>
+		
+		<profile>
+			<id>m2e</id>
+			<activation>
+				<property>
+					<name>m2e.version</name>
+				</property>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<!--This plugin's configuration is used to store Eclipse m2e settings 
+							only. It has no influence on the Maven build itself. -->
+						<plugin>
+							<groupId>org.eclipse.m2e</groupId>
+							<artifactId>lifecycle-mapping</artifactId>
+							<configuration>
+								<lifecycleMappingMetadata>
+									<pluginExecutions>
+										<pluginExecution>
+											<pluginExecutionFilter>
+												<groupId>org.codehaus.mojo</groupId>
+												<artifactId>xml-maven-plugin</artifactId>
+												<versionRange>[1.0,)</versionRange>
+												<goals>
+													<goal>transform</goal>
+												</goals>
+											</pluginExecutionFilter>
+											<action>
+												<ignore />
+											</action>
+										</pluginExecution>
+									</pluginExecutions>
+								</lifecycleMappingMetadata>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
 			</build>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,16 @@
 	<properties>
 		<java-version>17</java-version>
 		<maven-version>3.8.1</maven-version>
-		<uima-version>3.5.0</uima-version>
-		<saxon.version>8.7</saxon.version>
+		<uima-version>3.6.0-SNAPSHOT</uima-version>
+		<bnd-version>7.0.0</bnd-version>
+		<saxon-version>8.7</saxon-version>
 		<typesystem-stylesheet-location>${basedir}/../doc/typesystem.xslt</typesystem-stylesheet-location>
+		
+		<osgi-export-package>!*</osgi-export-package>
+		<osgi-export-package-test>${osgi-export-package};-split-package:=merge-first</osgi-export-package-test>
+		<osgi-import-package>*</osgi-import-package>
+		<osgi-import-package-test>*</osgi-import-package-test>
+		<osgi-capabilities />
 	</properties>
 
 	<distributionManagement>
@@ -134,6 +141,12 @@
 
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
+					<version>${bnd-version}</version>
+				</plugin>
+
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
@@ -247,44 +260,66 @@
 
 	<profiles>
 		<profile>
-			<id>osgi-module</id>
+			<id>bnd-osgi-module</id>
 			<activation>
 				<file>
-					<exists>marker-osgi-module</exists>
+					<exists>marker-bnd-osgi-module</exists>
 				</file>
 			</activation>
+
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.apache.felix</groupId>
-						<artifactId>maven-bundle-plugin</artifactId>
+						<groupId>biz.aQute.bnd</groupId>
+						<artifactId>bnd-maven-plugin</artifactId>
 						<extensions>true</extensions>
-						<configuration>
-							<instructions>
-								<Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
-								<_dsannotations>*</_dsannotations>
-								<_metatypeannotations>*</_metatypeannotations>
-							</instructions>
-						</configuration>
 						<executions>
 							<execution>
-								<id>bundle-manifest</id>
-								<phase>process-classes</phase>
+								<id>bnd-process</id>
 								<goals>
-									<goal>manifest</goal>
+									<goal>bnd-process</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>bnd-jar</id>
+								<goals>
+									<goal>jar</goal>
 								</goals>
 								<configuration>
-									<niceManifest>true</niceManifest>
-									<exportScr>true</exportScr>
-									<scrLocation>${project.basedir}/OSGI-INF/..</scrLocation>
-									<manifestLocation>${project.basedir}/META-INF</manifestLocation>
-							<!-- 
-							  - Enabling this currently seems to cause spurious exceptions in Eclipse 
- 							<supportIncrementalBuild>true</supportIncrementalBuild>
-							  -->
+									<bnd><![CDATA[
+										Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+										Export-Package: ${osgi-export-package}
+										Import-Package: ${osgi-import-package}
+										${osgi-capabilities}
+										-plugin.uima: org.apache.uima.tools.bnd.UimaBndPlugin
+									]]></bnd>
+								</configuration>
+							</execution>
+							<!-- Integration Test Configuration -->
+							<execution>
+								<id>bnd-test-jar</id>
+								<goals>
+									<goal>test-jar</goal>
+								</goals>
+								<configuration>
+									<artifactFragment>true</artifactFragment>
+									<bnd><![CDATA[
+										Fragment-Host: ${project.groupId}.${project.artifactId}
+										Bundle-SymbolicName: ${project.groupId}.${project.artifactId}-tests
+										Export-Package: ${osgi-export-package-test}
+										Import-Package: ${osgi-import-package-test}
+										-plugin.uima: org.apache.uima.tools.bnd.UimaBndPlugin
+									]]></bnd>
 								</configuration>
 							</execution>
 						</executions>
+						<dependencies>
+							<dependency>
+								<groupId>org.apache.uima</groupId>
+								<artifactId>uima-bnd-plugin</artifactId>
+								<version>${uima-version}</version>
+							</dependency>
+						</dependencies>
 					</plugin>
 
 					<plugin>
@@ -319,6 +354,7 @@
 				</plugins>
 			</build>
 		</profile>
+
 		<profile>
 			<id>typesystem-module</id>
 			<activation>
@@ -381,7 +417,7 @@
 							<dependency>
 								<groupId>net.sf.saxon</groupId>
 								<artifactId>saxon</artifactId>
-								<version>${saxon.version}</version>
+								<version>${saxon-version}</version>
 							</dependency>
 						</dependencies>
 					</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
 	</scm>
 
 	<properties>
-		<java-version>1.8</java-version>
-		<javadoc.opts>-Xdoclint:none</javadoc.opts>
-		<uima-version>3.4.0-SNAPSHOT</uima-version>
+		<java-version>17</java-version>
+		<maven-version>3.8.1</maven-version>
+		<uima-version>3.5.0</uima-version>
 		<saxon.version>8.7</saxon.version>
 		<typesystem-stylesheet-location>${basedir}/../doc/typesystem.xslt</typesystem-stylesheet-location>
 	</properties>
@@ -59,14 +59,34 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-build-requirements</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>${maven-version}</version>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>${java-version}</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<source>${java-version}</source>
 					<target>${java-version}</target>
-					<optimize>true</optimize>
-					<debug>true</debug>
-					<showDeprecation>true</showDeprecation>
-					<showWarnings>true</showWarnings>
+					<release>${java-version}</release>
 				</configuration>
 			</plugin>
 
@@ -74,9 +94,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<configuration>
-					<outputDirectory>${project.build.directory}/docs/apidocs</outputDirectory>
-					<reportOutputDirectory>${project.build.directory}/docs/apidocs</reportOutputDirectory>
-					<additionalparam>${javadoc.opts}</additionalparam>
 					<tags>
 						<tag>
 							<name>generated</name>
@@ -90,6 +107,26 @@
 							<name>modifiable</name>
 							<placement>X</placement>
 						</tag>
+						<tag>
+							<name>forRemoval</name>
+							<placement>a</placement>
+							<head>To be removed in version:</head>
+						</tag>
+						<tag>
+							<name>apiNote</name>
+							<placement>a</placement>
+							<head>API note:</head>
+						</tag>
+						<tag>
+							<name>implSpec</name>
+							<placement>a</placement>
+							<head>Implementation specification:</head>
+						</tag>
+						<tag>
+							<name>implNote</name>
+							<placement>a</placement>
+							<head>Implementation note:</head>
+						</tag>
 					</tags>
 				</configuration>
 			</plugin>
@@ -99,8 +136,14 @@
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.5.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.8.2</version>
+					<version>3.1.3</version>
 					<executions>
 						<execution>
 							<id>default-deploy</id>
@@ -115,13 +158,13 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.3</version>
+					<version>3.13.0</version>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>3.10.0</version>
 				</plugin>
 
 				<plugin>
@@ -133,19 +176,43 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>xml-maven-plugin</artifactId>
-					<version>1.0</version>
+					<version>1.1.0</version>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.0.2</version>
+					<version>3.3.1</version>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>2.6</version>
+					<version>3.7.1</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.4.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>3.2.6</version>
+				</plugin>
+				
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.5.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>5.1.9</version>
 				</plugin>
 
 				<!--This plugin's configuration is used to store Eclipse m2e settings 
@@ -159,15 +226,9 @@
 							<pluginExecutions>
 								<pluginExecution>
 									<pluginExecutionFilter>
-										<groupId>
-											org.codehaus.mojo
-										</groupId>
-										<artifactId>
-											xml-maven-plugin
-										</artifactId>
-										<versionRange>
-											[1.0,)
-										</versionRange>
+										<groupId>org.codehaus.mojo</groupId>
+										<artifactId>xml-maven-plugin</artifactId>
+										<versionRange>[1.0,)</versionRange>
 										<goals>
 											<goal>transform</goal>
 										</goals>
@@ -197,20 +258,12 @@
 					<plugin>
 						<groupId>org.apache.felix</groupId>
 						<artifactId>maven-bundle-plugin</artifactId>
-						<version>5.1.6</version>
 						<extensions>true</extensions>
 						<configuration>
 							<instructions>
 								<Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
 								<_dsannotations>*</_dsannotations>
 								<_metatypeannotations>*</_metatypeannotations>
-								<Require-Capability>
-									osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
-								</Require-Capability>
-								<Provide-Capability>
-									osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider,
-									osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.JCasClassProvider
-								</Provide-Capability>
 							</instructions>
 						</configuration>
 						<executions>
@@ -237,7 +290,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-clean-plugin</artifactId>
-						<version>3.2.0</version>
 						<executions>
 							<execution>
 								<phase>clean</phase>
@@ -403,7 +455,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>


### PR DESCRIPTION
**What's in the PR**
- Minimum Java verison 8 -> 17
- Removed outdated JavaDoc options
- Removed default OSGI capability configurations
- Added additional JavaDoc tag configurations
- UIMA 3.4.0-SNAPSHOT -> 3.6.0
- maven-enforcer-plugin -> 3.5.0
- maven-deploy-plugin 2.8.2 -> 3.1.3
- maven-compiler-plugin 3.3 -> 3.13.0
- maven-javadoc-plugin 3.0.1 -> 3.11.1
- maven-xml-plugin 1.0 -> 1.1.0
- maven-resources-plugin 3.0.2 -> 3.3.1
- maven-assembly-plugin 2.6 -> 3.7.1
- maven-clean-plugin 3.2.0 -> 3.4.0
- maven-gpg-plugin 3.0.1 -> 3.2.7
- maven-surefire-plugin -> 3.5.2
- maven-bundle-plugin 5.1.6 -> removed
- bnd-maven-plugin -> 7.1.0
- Upgraded build actions

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
